### PR TITLE
[MXNet-1404] Implement storage tagging, the first half of the memory profiler

### DIFF
--- a/include/mxnet/c_api.h
+++ b/include/mxnet/c_api.h
@@ -314,6 +314,13 @@ MXNET_DLL int MXSetProcessProfilerState(int state, int profile_process,
 MXNET_DLL int MXSetProfilerState(int state);
 
 /*!
+ * \brief Set the scope of profiler for current process
+ * \param scope indicate the working scope of profiler
+ * \return 0 when success, -1 when failure happens.
+ */
+MXNET_DLL int MXSetProfilerScope(const char* scope);
+
+/*!
  * \brief Save profile and stop profiler
  * \param finished true if stat output should stop after this point
  * \param profile_process an int,

--- a/python/mxnet/gluon/block.py
+++ b/python/mxnet/gluon/block.py
@@ -31,6 +31,7 @@ from .. import symbol, ndarray, initializer, np_symbol
 from ..symbol import Symbol
 from ..ndarray import NDArray
 from .. import name as _name
+from .. import profiler as _profiler
 from .parameter import Parameter, ParameterDict, DeferredInitializationError
 from .utils import _indent, _brief_print_list, HookHandle
 from .utils import _check_same_symbol_type, _check_all_np_ndarrays
@@ -52,18 +53,24 @@ class _BlockScope(object):
 
     @staticmethod
     def create(prefix, params, hint):
-        """Creates prefix and params for new `Block`."""
+        """
+        Creates prefix, params, and profiler scope name for new `Block`.
+        The profiler scope is to support the GPU memory profiler.
+        """
         current = getattr(_BlockScope._current, "value", None)
         if current is None:
             if prefix is None:
                 if not hasattr(_name.NameManager._current, "value"):
                     _name.NameManager._current.value = _name.NameManager()
                 prefix = _name.NameManager._current.value.get(None, hint) + '_'
+            # replace the trailing underscore with colon
+            profiler_scope_name = (prefix[:-1] if prefix.endswith('_') \
+                                   else prefix) + ":"
             if params is None:
                 params = ParameterDict(prefix)
             else:
                 params = ParameterDict(params.prefix, params)
-            return prefix, params
+            return prefix, params, profiler_scope_name
 
         if prefix is None:
             count = current._counter.get(hint, 0)
@@ -74,7 +81,11 @@ class _BlockScope(object):
             params = ParameterDict(parent.prefix+prefix, parent._shared)
         else:
             params = ParameterDict(params.prefix, params)
-        return current._block.prefix+prefix, params
+        # replace the trailing underscore with colon
+        profiler_scope_name = (prefix[:-1] if prefix.endswith('_') \
+                               else prefix) + ":"
+        return current._block.prefix + prefix, params, \
+               current._block._profiler_scope_name + profiler_scope_name
 
     def __enter__(self):
         if self._block._empty_prefix:
@@ -83,6 +94,8 @@ class _BlockScope(object):
         _BlockScope._current.value = self
         self._name_scope = _name.Prefix(self._block.prefix)
         self._name_scope.__enter__()
+        self._profiler_scope = _profiler.Scope(self._block._profiler_scope_name)
+        self._profiler_scope.__enter__()
         return self
 
     def __exit__(self, ptype, value, trace):
@@ -90,6 +103,8 @@ class _BlockScope(object):
             return
         self._name_scope.__exit__(ptype, value, trace)
         self._name_scope = None
+        self._profiler_scope.__exit__()
+        self._profiler_scope = None
         _BlockScope._current.value = self._old_scope
 
 
@@ -273,7 +288,8 @@ class Block(object):
     """
     def __init__(self, prefix=None, params=None):
         self._empty_prefix = prefix == ''
-        self._prefix, self._params = _BlockScope.create(prefix, params, self._alias())
+        self._prefix, self._params, self._profiler_scope_name = \
+                _BlockScope.create(prefix, params, self._alias())
         self._name = self._prefix[:-1] if self._prefix.endswith('_') else self._prefix
         self._scope = _BlockScope(self)
         self._children = OrderedDict()

--- a/python/mxnet/optimizer/optimizer.py
+++ b/python/mxnet/optimizer/optimizer.py
@@ -36,6 +36,7 @@ from ..ndarray import (sgd_update, sgd_mom_update, adam_update, rmsprop_update, 
                        preloaded_multi_sgd_mom_update, preloaded_multi_mp_sgd_update,
                        preloaded_multi_mp_sgd_mom_update, lamb_update_phase1, lamb_update_phase2)
 from ..ndarray import sparse
+from ..profiler import Scope
 from ..random import normal
 from ..util import is_np_array
 
@@ -2015,7 +2016,8 @@ class Updater(object):
                 indices[i] = py_str(idx)
                 idx = indices[i]
             if idx not in self.states:
-                self.states[idx] = self.optimizer.create_state_multi_precision(idx, weights[i])
+                with Scope("optimizer_state"):
+                    self.states[idx] = self.optimizer.create_state_multi_precision(idx, weights[i])
                 self.states_synced[idx] = True
             elif not self.states_synced[idx]:
                 self.states[idx] = \

--- a/python/mxnet/symbol/register.py
+++ b/python/mxnet/symbol/register.py
@@ -29,6 +29,7 @@ from ..base import mx_uint, check_call, _LIB, py_str
 from ..symbol_doc import _build_doc
 from ..base import _Null, _init_op_module, _is_np_op, _output_is_list
 from ..name import NameManager
+from ..profiler import Scope
 # pylint: enable=unused-import
 
 
@@ -192,6 +193,8 @@ def %s(*%s, **kwargs):"""%(func_name, arr_name))
             key_var_num_args, key_var_num_args))
 
             code.append("""
+    keys.append('profiler_scope')
+    vals.append(Scope._current.value.name)
     return _symbol_creator(%d, sym_args, sym_kwargs, keys, vals, name, %s, %s)"""%(
                 handle.value, str(is_np_op), str(output_is_list)))
     else:
@@ -245,6 +248,8 @@ def %s(%s):"""%(func_name, ', '.join(signature)))
     if not hasattr(NameManager._current, "value"):
         NameManager._current.value = NameManager()
     name = NameManager._current.value.get(name, '%s')
+    _keys.append('profiler_scope')
+    _vals.append(Scope._current.value.name)
     return _symbol_creator(%d, None, sym_kwargs, _keys, _vals, name, %s, %s)"""%(
         func_name.lower(), handle.value, str(is_np_op), str(output_is_list)))
 

--- a/src/c_api/c_api.cc
+++ b/src/c_api/c_api.cc
@@ -54,6 +54,7 @@
 #include "../operator/tensor/matrix_op-inl.h"
 #include "../operator/tvmop/op_module.h"
 #include "../common/utils.h"
+#include "../profiler/gpu_memory_profiler.h"
 #include "nnvm/pass_functions.h"
 
 using namespace mxnet;
@@ -808,7 +809,8 @@ void CreateNDArray(const DataType* shape,
   }
   *out = new NDArray(requested_shape,
                      Context::Create(static_cast<Context::DeviceType>(dev_type), dev_id),
-                     delay_alloc != 0, dtype);
+                     delay_alloc != 0, dtype,
+                     profiler::GpuMemoryProfiler::GetCurrentScope());
 }
 
 int MXNDArrayCreate(const uint32_t *shape,
@@ -820,7 +822,8 @@ int MXNDArrayCreate(const uint32_t *shape,
   API_BEGIN();
   *out = new NDArray(mxnet::TShape(shape, shape + ndim),
                      Context::Create(static_cast<Context::DeviceType>(dev_type), dev_id),
-                     delay_alloc != 0);
+                     delay_alloc != 0, mshadow::default_type_flag,
+                     profiler::GpuMemoryProfiler::GetCurrentScope());
   API_END();
 }
 
@@ -876,7 +879,9 @@ int MXNDArrayCreateSparseEx(int storage_type,
       mxnet::TShape(shape, shape + ndim),
       Context::Create(static_cast<Context::DeviceType>(dev_type), dev_id),
       delay_alloc != 0,
-      dtype, aux_types, aux_shapes);
+      dtype, aux_types, aux_shapes,
+      mxnet::TShape(mshadow::Shape1(0)),
+      profiler::GpuMemoryProfiler::GetCurrentScope());
   API_END();
 }
 
@@ -2189,14 +2194,16 @@ int MXNDArrayGetSharedMemHandle(NDArrayHandle handle, int* shared_pid, int* shar
 int MXNDArrayCreateFromSharedMem(int shared_pid, int shared_id, const uint32_t *shape,
                                  uint32_t ndim, int dtype, NDArrayHandle *out) {
   API_BEGIN();
-  *out = new NDArray(shared_pid, shared_id, mxnet::TShape(shape, shape + ndim), dtype);
+  *out = new NDArray(shared_pid, shared_id, mxnet::TShape(shape, shape + ndim), dtype,
+                     profiler::GpuMemoryProfiler::GetCurrentScope());
   API_END();
 }
 
 int MXNDArrayCreateFromSharedMemEx(int shared_pid, int shared_id, const int *shape,
                                    int ndim, int dtype, NDArrayHandle *out) {
   API_BEGIN();
-  *out = new NDArray(shared_pid, shared_id, mxnet::TShape(shape, shape + ndim), dtype);
+  *out = new NDArray(shared_pid, shared_id, mxnet::TShape(shape, shape + ndim), dtype,
+                     profiler::GpuMemoryProfiler::GetCurrentScope());
   API_END();
 }
 

--- a/src/c_api/c_api_ndarray.cc
+++ b/src/c_api/c_api_ndarray.cc
@@ -37,6 +37,7 @@
 #include "../common/exec_utils.h"
 #include "../imperative/imperative_utils.h"
 #include "../imperative/cached_op.h"
+#include "../profiler/gpu_memory_profiler.h"
 
 using namespace mxnet;
 
@@ -97,6 +98,7 @@ void MXImperativeInvokeImpl(AtomicSymbolCreator creator,
 
   nnvm::NodeAttrs attrs = imperative::ParseAttrs(op, num_inputs, num_params,
                                                  param_keys, param_vals);
+  attrs.dict["__profiler_scope__"] = profiler::GpuMemoryProfiler::GetCurrentScope();
 
   int infered_num_outputs;
   int num_visible_outputs;

--- a/src/c_api/c_api_profile.cc
+++ b/src/c_api/c_api_profile.cc
@@ -33,6 +33,7 @@
 #include <stack>
 #include "./c_api_common.h"
 #include "../profiler/profiler.h"
+#include "../profiler/gpu_memory_profiler.h"
 
 namespace mxnet {
 
@@ -360,6 +361,12 @@ int MXDumpProcessProfile(int finished, int profile_process, KVStoreHandle kvStor
 
 int MXSetProfilerState(int state) {
   return MXSetProcessProfilerState(state, static_cast<int>(ProfileProcess::kWorker), nullptr);
+}
+
+int MXSetProfilerScope(const char* const scope) {
+  API_BEGIN();
+  profiler::GpuMemoryProfiler::SetCurrentScope(scope);
+  API_END();
 }
 
 int MXSetProcessProfilerState(int state, int profile_process, KVStoreHandle kvStoreHandle) {

--- a/src/c_api/c_api_symbolic.cc
+++ b/src/c_api/c_api_symbolic.cc
@@ -41,10 +41,20 @@ void RegisterLegacyOpProp();
 void RegisterLegacyNDFunc();
 }
 const std::vector<std::string> kHiddenKeys = {
-  "ctx_group", "lr_mult", "wd_mult", "force_mirroring", "mirror_stage"
+  "ctx_group",
+  "lr_mult",
+  "wd_mult",
+  "force_mirroring",
+  "mirror_stage",
+  "profiler_scope"
 };
 const std::vector<std::string> kReplacedHiddenKeys = {
-  "__ctx_group__", "__lr_mult__", "__wd_mult__", "__force_mirroring__", "__mirror_stage__"
+  "__ctx_group__",
+  "__lr_mult__",
+  "__wd_mult__",
+  "__force_mirroring__",
+  "__mirror_stage__",
+  "__profiler_scope__"
 };
 const char *kNamespaceSeparator = "$";
 

--- a/src/common/utils.h
+++ b/src/common/utils.h
@@ -31,6 +31,7 @@
 #include <nnvm/node.h>
 #include <mxnet/engine.h>
 #include <mxnet/ndarray.h>
+#include <mxnet/storage.h>
 #include <mxnet/op_attr_types.h>
 #include <mxnet/graph_attr_types.h>
 #include <nnvm/graph_attr_types.h>
@@ -727,30 +728,45 @@ MSHADOW_XINLINE int ilog2ui(unsigned int a) {
  * \brief Return an NDArray of all zeros.
  */
 inline NDArray InitZeros(const NDArrayStorageType stype, const mxnet::TShape &shape,
-                         const Context &ctx, const int dtype) {
+                         const Context &ctx, const int dtype,
+                         const std::string &profiler_scope,
+                         const std::string &arg_name,
+                         const Storage::DataStruct data_struct) {
   // NDArray with default storage
   if (stype == kDefaultStorage) {
-    NDArray ret(shape, ctx, false, dtype);
+    NDArray ret(shape, ctx, false, dtype,
+                profiler_scope, arg_name, data_struct);
     ret = 0;
     return ret;
   }
   // NDArray with non-default storage. Storage allocation is always delayed.
-  return NDArray(stype, shape, ctx, true, dtype);
+  return NDArray(stype, shape, ctx, true, dtype,
+                 {}, {}, mxnet::TShape(mshadow::Shape1(0)),
+                 profiler_scope, arg_name, data_struct);
 }
 
 /*!
  * \brief Helper to add a NDArray of zeros to a std::vector.
  */
-inline void EmplaceBackZeros(const NDArrayStorageType stype, const mxnet::TShape &shape,
-                             const Context &ctx, const int dtype,
-                             std::vector<NDArray> *vec) {
+inline void EmplaceBackZeros(const NDArrayStorageType stype,
+                             const mxnet::TShape &shape,
+                             const Context &ctx,
+                             const int dtype,
+                             std::vector<NDArray> *vec,
+                             const std::string &profiler_scope,
+                             const std::string &arg_name,
+                             const Storage::DataStruct data_struct) {
   // NDArray with default storage
   if (stype == kDefaultStorage) {
-    vec->emplace_back(shape, ctx, false, dtype);
+    vec->emplace_back(shape, ctx, false, dtype,
+                      profiler_scope, arg_name, data_struct);
     vec->back() = 0;
   } else {
     // NDArray with non-default storage. Storage allocation is always delayed.
-    vec->emplace_back(stype, shape, ctx, true, dtype);
+    vec->emplace_back(stype, shape, ctx, true, dtype,
+                      std::vector<int>(), mxnet::ShapeVector(),
+                      mxnet::TShape(mshadow::Shape1(0)),
+                      profiler_scope, arg_name, data_struct);
   }
 }
 
@@ -900,6 +916,20 @@ inline int np_binary_out_infer_type(const int type1, const int type2) {
     return mshadow::kInt32;
   }
   return get_more_precise_type(type1, type2);
+}
+
+inline const std::string
+NodeAttrsGetProfilerScope(const nnvm::NodeAttrs& attrs) {
+  // obtain the profiler scope name, if assigned previously
+  std::string profiler_scope = MXNET_STORAGE_DEFAULT_PROFILER_SCOPE_CSTR;
+  const std::unordered_map<std::string, std::string>&
+      node_attrs_dict = attrs.dict;
+  const std::unordered_map<std::string, std::string>::const_iterator
+      profiler_scope_iter  = node_attrs_dict.find("__profiler_scope__");
+  if (profiler_scope_iter != node_attrs_dict.end()) {
+    profiler_scope = profiler_scope_iter->second;
+  }
+  return profiler_scope;
 }
 
 }  // namespace common

--- a/src/executor/graph_executor.cc
+++ b/src/executor/graph_executor.cc
@@ -23,6 +23,7 @@
  * \brief graph executor
  */
 #include <mxnet/base.h>
+#include <mxnet/storage.h>
 #include <nnvm/graph.h>
 #include <nnvm/pass_functions.h>
 #include <vector>
@@ -517,9 +518,12 @@ void GraphExecutor::InitArguments(const nnvm::IndexedGraph& idx,
     const int inferred_dtype = inferred_dtypes[eid];
     const NDArrayStorageType inferred_stype = (NDArrayStorageType) inferred_stypes[eid];
     const std::string& arg_name = idx[nid].source->attrs.name;
+    const std::string profiler_scope = common::NodeAttrsGetProfilerScope(idx[nid].source->attrs);
     if (mutable_nodes.count(nid)) {  // aux_states
       EmplaceBackZeros(inferred_stype, inferred_shape, aux_state_ctxes[aux_top],
-                       inferred_dtype, aux_state_vec);
+                       inferred_dtype, aux_state_vec,
+                       profiler_scope + "aux_state:",
+                       arg_name, Storage::DataStruct::kAuxState);
       data_entry_[eid] = aux_state_vec->back();
       aux_state_map_.emplace(arg_name, aux_state_vec->back());
       ++aux_top;
@@ -529,7 +533,9 @@ void GraphExecutor::InitArguments(const nnvm::IndexedGraph& idx,
       }
     } else {  // in_args
       EmplaceBackZeros(inferred_stype, inferred_shape, in_arg_ctxes[arg_top],
-                       inferred_dtype, in_arg_vec);
+                       inferred_dtype, in_arg_vec,
+                       profiler_scope + "param:",
+                       arg_name, Storage::DataStruct::kParameter);
       data_entry_[eid] = in_arg_vec->back();
       if (log_verbose_) {
         LOG(INFO) << "\tassign data entry\t" << eid << "\tas "
@@ -544,7 +550,9 @@ void GraphExecutor::InitArguments(const nnvm::IndexedGraph& idx,
         auto grad_eid = idx.entry_id(idx.outputs()[grad_oid]);
         auto grad_stype = (NDArrayStorageType) inferred_stypes[grad_eid];
         EmplaceBackZeros(grad_stype, inferred_shape, arg_grad_ctxes[arg_top],
-                         inferred_dtype, arg_grad_vec);
+                         inferred_dtype, arg_grad_vec,
+                         profiler_scope + "param_grad:",
+                         arg_name, Storage::DataStruct::kParameterGrad);
         if (log_verbose_) {
           LOG(INFO) << "\tassign grad entry\t" << grad_eid << "\tas "
                     << common::stype_string(grad_stype);
@@ -589,6 +597,7 @@ void GraphExecutor::InitArguments(const nnvm::IndexedGraph& idx,
     const int inferred_dtype = inferred_dtypes[eid];
     const NDArrayStorageType inferred_stype = (NDArrayStorageType) inferred_stypes[eid];
     const std::string& arg_name = idx[nid].source->attrs.name;
+    const std::string profiler_scope = common::NodeAttrsGetProfilerScope(idx[nid].source->attrs);
     // aux_states
     if (mutable_nodes.count(nid)) {
       if (nullptr != shared_exec) {
@@ -610,7 +619,9 @@ void GraphExecutor::InitArguments(const nnvm::IndexedGraph& idx,
         aux_state_vec->emplace_back(aux_nd);
       } else {
         EmplaceBackZeros(inferred_stype, inferred_shape, aux_state_ctxes[aux_top],
-                         inferred_dtype, aux_state_vec);
+                         inferred_dtype, aux_state_vec,
+                         profiler_scope + "aux_state:",
+                         arg_name, Storage::DataStruct::kAuxState);
       }  // if (has_shared_exec)
       data_entry_[eid] = aux_state_vec->back();
       aux_state_map_.emplace(arg_name, aux_state_vec->back());
@@ -647,7 +658,9 @@ void GraphExecutor::InitArguments(const nnvm::IndexedGraph& idx,
         } else {
           // doesn't have shared_exec, or non-default storage
           EmplaceBackZeros(inferred_stype, inferred_shape, in_arg_ctxes[arg_top],
-                           inferred_dtype, in_arg_vec);
+                           inferred_dtype, in_arg_vec,
+                           profiler_scope + "in_arg:",
+                           arg_name, Storage::DataStruct::kParameter);
         }
         // gradient for model parameter
         if (kNullOp == grad_req_types[arg_top]) {
@@ -663,16 +676,20 @@ void GraphExecutor::InitArguments(const nnvm::IndexedGraph& idx,
           } else {
             // no need to reuse memory from shared_exec for gradient of non-default storage
             EmplaceBackZeros(grad_stype, inferred_shape, arg_grad_ctxes[arg_top],
-                             inferred_dtype, arg_grad_vec);
+                             inferred_dtype, arg_grad_vec,
+                             profiler_scope + "arg_grad:",
+                             arg_name, Storage::DataStruct::kParameterGrad);
           }
           grad_store_.emplace_back(grad_req_types[arg_top], arg_grad_vec->back());
         }
       } else {  // !shared_arg_names.count(arg_name)
         // model parameter, row_sparse ndarray sharing enabled
         bool enable_row_sparse_sharing = true;
-        in_arg_vec->emplace_back(ReshapeOrCreate(arg_name, inferred_shape, inferred_dtype,
+        in_arg_vec->emplace_back(ReshapeOrCreate(inferred_shape, inferred_dtype,
                                                  inferred_stype, in_arg_ctxes[arg_top],
-                                                 shared_buffer, enable_row_sparse_sharing));
+                                                 shared_buffer, enable_row_sparse_sharing,
+                                                 profiler_scope + "in_arg:",
+                                                 arg_name, Storage::DataStruct::kParameter));
         // gradient for model parameter, row_sparse ndarray sharing disabled
         if (kNullOp == grad_req_types[arg_top]) {
           arg_grad_vec->emplace_back();
@@ -681,10 +698,11 @@ void GraphExecutor::InitArguments(const nnvm::IndexedGraph& idx,
           auto grad_eid = idx.entry_id(idx.outputs()[grad_oid]);
           auto grad_stype = (NDArrayStorageType) inferred_stypes[grad_eid];
           bool enable_row_sparse_sharing = false;
-          arg_grad_vec->emplace_back(ReshapeOrCreate("grad of " + arg_name, inferred_shape,
-                                                     inferred_dtype, grad_stype,
-                                                     arg_grad_ctxes[arg_top], shared_buffer,
-                                                     enable_row_sparse_sharing));
+          arg_grad_vec->emplace_back(ReshapeOrCreate(inferred_shape, inferred_dtype,
+                                                     grad_stype, arg_grad_ctxes[arg_top],
+                                                     shared_buffer, enable_row_sparse_sharing,
+                                                     profiler_scope + "arg_grad:",
+                                                     arg_name, Storage::DataStruct::kParameterGrad));
           grad_store_.emplace_back(grad_req_types[arg_top], arg_grad_vec->back());
         }  // if (kNullOp == grad_req_types[arg_top])
       }  // if (shared_arg_names.count(arg_name))
@@ -1076,13 +1094,20 @@ void GraphExecutor::InitDataEntryMemory(std::vector<NDArray>* shared_pool) {
   CHECK_EQ(idx.num_node_entries(), vstorage.size());
   CHECK_EQ(data_entry_.size(), vshape.size());
   std::vector<Context> data_context(idx.num_node_entries());
-  std::vector<NDArrayStorageType> data_storage_type(idx.num_node_entries(), kUndefinedStorage);
+  std::vector<NDArrayStorageType> data_storage_type(
+      idx.num_node_entries(), kUndefinedStorage);
+  std::vector<std::string> data_storage_profiler_scope(
+      idx.num_node_entries());
+  std::vector<std::string> data_storage_name(idx.num_node_entries());
   for (uint32_t nid = 0; nid < idx.num_nodes(); ++nid) {
+    const std::string profiler_scope = common::NodeAttrsGetProfilerScope(idx[nid].source->attrs);
     for (uint32_t i = 0; i < idx[nid].source->num_outputs(); ++i) {
       auto eid = idx.entry_id(nid, i);
       data_context[eid] = vctx[nid];
       CHECK_NE(vstorage_type[eid], kUndefinedStorage);
       data_storage_type[eid] = (NDArrayStorageType) vstorage_type[eid];
+      data_storage_profiler_scope[eid] = profiler_scope;
+      data_storage_name[eid] = idx[nid].source->attrs.name;
     }
   }
 
@@ -1091,6 +1116,8 @@ void GraphExecutor::InitDataEntryMemory(std::vector<NDArray>* shared_pool) {
     Context ctx;
     size_t bytes;
     NDArrayStorageType stype;
+    std::string profiler_scope;
+    std::string name;
   };
   std::vector<PoolEntry> pool_info;
 
@@ -1105,11 +1132,21 @@ void GraphExecutor::InitDataEntryMemory(std::vector<NDArray>* shared_pool) {
     auto data_eid = idx.entry_id(nid, 0);
     // initialize based on storage_type
     if (stype != kDefaultStorage) {
-      data_entry_[data_eid] = NDArray(stype, vshape[eid], data_context[eid], true, vdtype[eid]);
+      data_entry_[data_eid] = NDArray(stype, vshape[eid], data_context[eid], true, vdtype[eid],
+                                      {}, {}, mxnet::TShape(mshadow::Shape1(0)),
+                                      data_storage_profiler_scope[eid],
+                                      data_storage_name[eid] + "_head_grad",
+                                      Storage::DataStruct::kDataEntry);
     } else if (!unknown_shape) {
-      data_entry_[data_eid] = NDArray(vshape[eid], data_context[eid], false, vdtype[eid]);
+      data_entry_[data_eid] = NDArray(vshape[eid], data_context[eid], false, vdtype[eid],
+                                      data_storage_profiler_scope[eid],
+                                      data_storage_name[eid] + "_head_grad",
+                                      Storage::DataStruct::kDataEntry);
     } else {
-      data_entry_[data_eid] = NDArray(data_context[eid], vdtype[eid]);
+      data_entry_[data_eid] = NDArray(data_context[eid], vdtype[eid],
+                                      data_storage_profiler_scope[eid],
+                                      data_storage_name[eid] + "_head_grad",
+                                      Storage::DataStruct::kDataEntry);
     }
     if (log_verbose_) {
       LOG(INFO) << "\tinit head_grad entry\t" << data_eid << "\tas "
@@ -1129,11 +1166,14 @@ void GraphExecutor::InitDataEntryMemory(std::vector<NDArray>* shared_pool) {
     if (storage_id < 0) continue;
     size_t sid = static_cast<size_t>(storage_id);
     if (sid >= pool_info.size()) {
-      pool_info.resize(sid + 1, PoolEntry{Context::CPU(), size_t(0), kUndefinedStorage});
+      pool_info.resize(sid + 1, PoolEntry{Context::CPU(), size_t(0), kUndefinedStorage,
+                                          "X", "X"});
     }
     PoolEntry& info = pool_info[sid];
     if (info.bytes == 0) {
-      info = PoolEntry{data_context[i], bytes, data_storage_type[i]};
+      info = PoolEntry{data_context[i], bytes, data_storage_type[i],
+                       data_storage_profiler_scope[i],
+                       data_storage_name[i]};
     } else {
       info.bytes = std::max(info.bytes, bytes);
     }
@@ -1165,7 +1205,10 @@ void GraphExecutor::InitDataEntryMemory(std::vector<NDArray>* shared_pool) {
 
   for (size_t i : sorted_pool_index) {
     const Context& ctx = pool_info[i].ctx;
-    size_t bytes = pool_info[i].bytes;
+    const size_t bytes = pool_info[i].bytes;
+    const std::string& data_entry_profiler_scope =
+        pool_info[i].profiler_scope;
+    const std::string& data_entry_name = pool_info[i].name;
     bool allocated = false;
     for (auto it = free_pool.lower_bound(bytes); it != free_pool.end(); ++it) {
       if (it->second.ctx() == ctx && it->first >= bytes) {
@@ -1182,7 +1225,8 @@ void GraphExecutor::InitDataEntryMemory(std::vector<NDArray>* shared_pool) {
       mxnet::TShape shape{static_cast<nnvm::dim_t>(nword)};
       // TODO(junwu): adding delay_alloc=true to create nd
       // is a temporary solution.
-      NDArray nd(shape, ctx, true);
+      NDArray nd(shape, ctx, true, mshadow::default_type_flag,
+                 data_entry_profiler_scope, data_entry_name);
       data_pool_[i] = nd;
       // put the new allocated arrays to shared pool
       if (shared_pool != nullptr)  {
@@ -1200,7 +1244,10 @@ void GraphExecutor::InitDataEntryMemory(std::vector<NDArray>* shared_pool) {
     auto storage_type = (NDArrayStorageType) vstorage_type[i];
     if (storage_type == kDefaultStorage) {
       if (!shape_is_known(vshape[i])) {
-        data_entry_[i] = NDArray(data_context[i], vdtype[i]);
+        data_entry_[i] = NDArray(data_context[i], vdtype[i],
+                                 data_storage_profiler_scope[i],
+                                 data_storage_name[i],
+                                 Storage::DataStruct::kDataEntry);
       } else {
         CHECK_GE(storage_id, 0) << "Do not support runtime shape op yet";
         const NDArray& src = data_pool_.at(storage_id);
@@ -1208,7 +1255,11 @@ void GraphExecutor::InitDataEntryMemory(std::vector<NDArray>* shared_pool) {
       }
     } else {
       data_entry_[i] = NDArray(storage_type, vshape[i], data_context[i],
-                               true, vdtype[i]);
+                               true, vdtype[i],
+                               {}, {}, mxnet::TShape(mshadow::Shape1(0)),
+                               data_storage_profiler_scope[i],
+                               data_storage_name[i],
+                               Storage::DataStruct::kDataEntry);
     }
     if (log_verbose_) {
       LOG(INFO) << "\tinit data entry\t" << i << "\tas " << common::stype_string(storage_type);

--- a/src/imperative/cached_op.cc
+++ b/src/imperative/cached_op.cc
@@ -924,8 +924,12 @@ OpStatePtr CachedOp::StaticForward(
       *outputs[i] = arrays[eid]->Detach();
     arrays[eid] = outputs[i];
     if (!outputs[i]->is_none()) continue;
+    nnvm::NodeAttrs attrs = idx[idx.outputs()[i].node_id].source->attrs;
     *outputs[i] = NDArray(static_cast<NDArrayStorageType>(stypes[eid]),
-                          shapes[eid], default_ctx, true, dtypes[eid]);
+                          shapes[eid], default_ctx, true, dtypes[eid],
+                          {}, {}, TShape(mshadow::Shape1(0)),
+                          common::NodeAttrsGetProfilerScope(attrs),
+                          attrs.name, Storage::DataStruct::kDataEntry);
   }
 
   StaticRunOps(default_ctx, g, state_ptr, arrays, 0, idx.num_nodes());

--- a/src/operator/linalg_impl.h
+++ b/src/operator/linalg_impl.h
@@ -39,6 +39,14 @@ inline void linalg_check_batch_size(int A, int B, int C) {
   CHECK_GT(A, 0) << "Zero batch size for arguments to linear algebra operator";
 }
 
+#ifdef __CUDACC__
+#define EPHEMERAL_GPU_STORAGE_ALLOC(func, var, dtype, size) \
+  Storage::Handle var = Storage::Get()->Alloc( \
+      sizeof(dtype) * size, Context::GPU(), \
+      "ephemeral:", #func"_"#var, \
+      Storage::DataStruct::kEphemeral);
+#endif
+
 //////////////////////////////// GEMM ////////////////////////////////////////////
 
 // CPU/GPU-versions of BLAS3 function "gemm". Please refer to the BLAS3-documentation
@@ -725,8 +733,9 @@ void linalg_potrf<gpu, DType>(const Tensor<gpu, 2, DType>& A, bool lower, Stream
   CHECK_NOTNULL(s); \
   check_potrf(A, lower); \
   int buffsize(linalg_potrf_buffsize(A, lower, s)); \
-  Storage::Handle buffer = Storage::Get()->Alloc(sizeof(DType)*buffsize, Context::GPU()); \
-  Storage::Handle info = Storage::Get()->Alloc(sizeof(int), Context::GPU()); \
+  EPHEMERAL_GPU_STORAGE_ALLOC(linalg_potrf, buffer, \
+      DType, buffsize); \
+  EPHEMERAL_GPU_STORAGE_ALLOC(linalg_potrf, info, int, 1); \
   CUSOLVER_CALL(cusolver##fname(Stream<gpu>::GetSolverHandle(s), \
                 (lower ? CUBLAS_FILL_MODE_UPPER : CUBLAS_FILL_MODE_LOWER), \
                 A.size(0), A.dptr_, A.stride_, static_cast<DType *>(buffer.dptr), buffsize, \
@@ -746,8 +755,9 @@ void linalg_batch_potrf<gpu, DType>(const Tensor<gpu, 3, DType>& A, bool lower, 
   CHECK_GT(A.size(0), 0); \
   check_potrf(A[0], lower); \
   int buffsize(linalg_potrf_buffsize(A[0], lower, s)); \
-  Storage::Handle buffer = Storage::Get()->Alloc(sizeof(DType)*buffsize, Context::GPU()); \
-  Storage::Handle info = Storage::Get()->Alloc(sizeof(int), Context::GPU()); \
+  EPHEMERAL_GPU_STORAGE_ALLOC(linalg_batch_potrf, buffer, \
+      DType, buffsize); \
+  EPHEMERAL_GPU_STORAGE_ALLOC(linalg_batch_potrf, info, int, 1); \
   for (mshadow::index_t i = 0; i < A.size(0); ++i) { \
     CUSOLVER_CALL(cusolver##fname(Stream<gpu>::GetSolverHandle(s), \
                  (lower ? CUBLAS_FILL_MODE_UPPER : CUBLAS_FILL_MODE_LOWER), \
@@ -818,7 +828,8 @@ void linalg_potri<gpu, DType>(const Tensor<gpu, 2, DType>& A, bool lower, Stream
   using namespace mxnet; \
   CHECK_NOTNULL(s); \
   check_potri(A, lower); \
-  Storage::Handle buffer = Storage::Get()->Alloc(sizeof(DType)*A.MSize(), Context::GPU()); \
+  EPHEMERAL_GPU_STORAGE_ALLOC(linalg_potri, buffer, \
+      DType, A.MSize()); \
   using namespace mshadow::cuda; \
   int ngrid = std::min(kMaxGridNum, \
                        static_cast<int>((A.MSize() + kBaseThreadNum - 1) / kBaseThreadNum)); \
@@ -842,7 +853,8 @@ void linalg_batch_potri<gpu, DType>(const Tensor<gpu, 3, DType>& A, bool lower, 
   CHECK_NOTNULL(s); \
   CHECK_GT(A.size(0), 0); \
   check_potri(A[0], lower); \
-  Storage::Handle buffer = Storage::Get()->Alloc(sizeof(DType)*A.MSize(), Context::GPU()); \
+  EPHEMERAL_GPU_STORAGE_ALLOC(linalg_batch_potri, buffer, \
+      DType, A.MSize()); \
   using namespace mshadow::cuda; \
   int ngrid = std::min(kMaxGridNum, \
                        static_cast<int>((A.MSize() + kBaseThreadNum - 1) / kBaseThreadNum)); \
@@ -1024,7 +1036,7 @@ void linalg_gelqf<gpu, DType>(const Tensor<gpu, 2, DType>& A, \
   check_gelqf(A, work); \
   int m(A.size(0)); \
   int lwork(work.size(0) - m); \
-  Storage::Handle info = Storage::Get()->Alloc(sizeof(int), Context::GPU()); \
+  EPHEMERAL_GPU_STORAGE_ALLOC(linalg_gelqf, info, int, 1); \
   CUSOLVER_CALL(cusolver##fname(Stream<gpu>::GetSolverHandle(s), \
                 A.size(1), m, A.dptr_ , A.stride_, work.dptr_, \
                 work.dptr_ + m, lwork, static_cast<int *>(info.dptr))); \
@@ -1048,7 +1060,7 @@ void linalg_orglq<gpu, DType>(const Tensor<gpu, 2, DType>& A, \
   check_gelqf(A, work); \
   int m(A.size(0)); \
   int lwork(work.size(0) - m); \
-  Storage::Handle info = Storage::Get()->Alloc(sizeof(int), Context::GPU()); \
+  EPHEMERAL_GPU_STORAGE_ALLOC(linalg_orglq, info, int, 1); \
   CUSOLVER_CALL(cusolver##fname(Stream<gpu>::GetSolverHandle(s), \
                 A.size(1), m, m, A.dptr_ , A.stride_, work.dptr_, \
                 work.dptr_ + m, lwork, static_cast<int *>(info.dptr))); \
@@ -1084,7 +1096,8 @@ int linalg_gelqf_workspace_query<gpu, DType>(const Tensor<gpu, 2, DType>& A, \
   CUSOLVER_CALL(cusolverDn##prefix##geqrf_bufferSize(Stream<gpu>::GetSolverHandle(s), \
                 A.size(1), m, A.dptr_ , A.stride_, &work1)); \
   int work2(0);  \
-  Storage::Handle tau = Storage::Get()->Alloc(sizeof(DType), Context::GPU()); \
+  EPHEMERAL_GPU_STORAGE_ALLOC(linalg_gelqf_workspace_query, \
+      tau, DType, 1); \
   CUSOLVER_CALL(cusolverDn##prefix##orgqr_bufferSize(Stream<gpu>::GetSolverHandle(s), \
                 A.size(1), m, m, A.dptr_ , A.stride_, static_cast<DType *>(tau.dptr), &work2)); \
   Storage::Get()->Free(tau); \
@@ -1182,7 +1195,7 @@ void linalg_syevd<gpu, DType>(const Tensor<gpu, 2, DType>& A, \
   using mshadow::gpu; \
   CHECK_NOTNULL(s); \
   check_syevd(A, L); \
-  Storage::Handle info = Storage::Get()->Alloc(sizeof(int), Context::GPU()); \
+  EPHEMERAL_GPU_STORAGE_ALLOC(linalg_syevd, info, int, 1); \
   CUSOLVER_CALL(cusolver##fname(Stream<gpu>::GetSolverHandle(s), \
                 CUSOLVER_EIG_MODE_VECTOR, CUBLAS_FILL_MODE_UPPER, \
                 A.size(0), A.dptr_ , A.stride_, L.dptr_, work.dptr_, \
@@ -1302,7 +1315,7 @@ void linalg_gesvd<gpu, DType>(const Tensor<gpu, 2, DType>& UT, \
   using namespace mxnet; \
   using mshadow::gpu; \
   check_gesvd(UT, L, V); \
-  Storage::Handle info = Storage::Get()->Alloc(sizeof(int), Context::GPU()); \
+  EPHEMERAL_GPU_STORAGE_ALLOC(linalg_gesvd, info, int, 1); \
   CUSOLVER_CALL(cusolver##fname(Stream<gpu>::GetSolverHandle(s), \
                 'O', 'S', V.size(1), V.size(0), V.dptr_, V.stride_, L.dptr_, V.dptr_, V.stride_, \
                 UT.dptr_, UT.stride_, work.dptr_, work.size(0), \
@@ -1422,8 +1435,9 @@ void linalg_batch_getrf<gpu, DType>(const Tensor<gpu, 3, DType>& A, \
   using namespace mxnet; \
   using namespace mxnet::op::mxnet_op; \
   CHECK_NOTNULL(s); \
-  Storage::Handle info = Storage::Get()->Alloc(sizeof(int) * A.size(0), Context::GPU()); \
-  Storage::Handle A_ptr_buf = Storage::Get()->Alloc(sizeof(DType *) * A.size(0), Context::GPU()); \
+  EPHEMERAL_GPU_STORAGE_ALLOC(linalg_batch_getrf, info, int, A.size(0)); \
+  EPHEMERAL_GPU_STORAGE_ALLOC(linalg_batch_getrf, A_ptr_buf, \
+      DType *, A.size(0)); \
   DType **A_ptr = static_cast<DType **>(A_ptr_buf.dptr); \
   Kernel<set_matrix, gpu>::Launch(s, A.size(0), \
                                   A_ptr, A.dptr_, \
@@ -1511,10 +1525,12 @@ void linalg_batch_getri<gpu, DType>(const Tensor<gpu, 3, DType>& A, \
   using namespace mxnet; \
   using namespace mxnet::op::mxnet_op; \
   CHECK_NOTNULL(s); \
-  Storage::Handle info = Storage::Get()->Alloc(sizeof(int) * A.size(0), Context::GPU()); \
-  Storage::Handle A_ptr_buf = Storage::Get()->Alloc(sizeof(DType *) * A.size(0), Context::GPU()); \
+  EPHEMERAL_GPU_STORAGE_ALLOC(linalg_batch_getri, info, int, A.size(0)); \
+  EPHEMERAL_GPU_STORAGE_ALLOC(linalg_batch_getri, \
+      A_ptr_buf, DType *, A.size(0)); \
   DType **A_ptr = static_cast<DType **>(A_ptr_buf.dptr); \
-  Storage::Handle LU_ptr_buf = Storage::Get()->Alloc(sizeof(DType *) * A.size(0), Context::GPU()); \
+  EPHEMERAL_GPU_STORAGE_ALLOC(linalg_batch_getri, \
+      LU_ptr_buf, DType *, A.size(0)); \
   DType **LU_ptr = static_cast<DType **>(LU_ptr_buf.dptr); \
   Kernel<set_matrix, gpu>::Launch(s, A.size(0), \
                                   A_ptr, A.dptr_, \

--- a/src/operator/nn/cudnn/cudnn_convolution-inl.h
+++ b/src/operator/nn/cudnn/cudnn_convolution-inl.h
@@ -761,7 +761,11 @@ class CuDNNConvolutionOp {
   void ReserveElements(const std::vector<size_t> &elements) {
     std::vector<Storage::Handle> handles;
     for (size_t alloc_element : elements)
-        handles.push_back(Storage::Get()->Alloc(alloc_element * sizeof(DType), Context::GPU()));
+        handles.push_back(Storage::Get()->Alloc(
+            alloc_element * sizeof(DType),
+            Context::GPU(),
+            "ephemeral:", "conv_reserve",
+            Storage::DataStruct::kEphemeral));
     for (auto &handle : handles)
         Storage::Get()->DirectFree(handle);
   }

--- a/src/operator/nn/cudnn/cudnn_deconvolution-inl.h
+++ b/src/operator/nn/cudnn/cudnn_deconvolution-inl.h
@@ -764,7 +764,11 @@ class CuDNNDeconvolutionOp {
   void ReserveElements(const std::vector<size_t> &elements) {
     std::vector<Storage::Handle> handles;
     for (size_t alloc_element : elements)
-        handles.push_back(Storage::Get()->Alloc(alloc_element * sizeof(DType), Context::GPU()));
+        handles.push_back(Storage::Get()->Alloc(
+            alloc_element * sizeof(DType),
+            Context::GPU(),
+            "ephemeral:", "deconv_reserve",
+            Storage::DataStruct::kEphemeral));
     for (auto &handle : handles)
         Storage::Get()->DirectFree(handle);
   }

--- a/src/operator/rnn-inl.h
+++ b/src/operator/rnn-inl.h
@@ -1384,7 +1384,11 @@ class RNNOp {
                                                 &reserve_space_byte_));
       workspace_size_ = workspace_byte_ / sizeof(DType);
       // Allocate the reserve space
-      reserve_space_ = Storage::Get()->Alloc(reserve_space_byte_, Context::GPU(s->dev_id));
+      reserve_space_ = Storage::Get()->Alloc(
+          reserve_space_byte_,
+          Context::GPU(s->dev_id),
+          "cudnn_rnn:", "reserve_space",
+          Storage::DataStruct::kDataEntry);
       // Check that number of params are correct
       size_t cudnn_param_size;
       CUDNN_CALL(cudnnGetRNNParamsSize(s->dnn_handle_,

--- a/src/profiler/gpu_memory_profiler.cc
+++ b/src/profiler/gpu_memory_profiler.cc
@@ -1,0 +1,129 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+#include <dmlc/parameter.h>
+#include "./gpu_memory_profiler.h"
+
+#ifdef _WIN32
+#include <windows.h>
+#include <tchar.h>
+#endif
+#include <ctime>
+#include <string>
+
+namespace mxnet {
+namespace profiler {
+
+/// \brief Return the path to the temporary directory.
+///        The implementation is taken from `boost::temp_directory_path`
+static std::string temp_dir_path() {
+#ifdef _WIN32
+#define TEMP_DIR_MAX_LEN 1024
+  TCHAR temp_dir_c_str[TEMP_DIR_MAX_LEN];
+  GetTempPath(TEMP_DIR_MAX_LEN,
+      temp_dir_c_str);
+  return std::string(temp_dir_c_str);
+#undef MAX_PATH
+#else  // !_WIN32
+  const char* temp_dir_c_str = NULL;
+
+  (temp_dir_c_str = std::getenv("TMPDIR")) ||
+  (temp_dir_c_str = std::getenv("TMP")) ||
+  (temp_dir_c_str = std::getenv("TEMP")) ||
+  (temp_dir_c_str = std::getenv("TEMPDIR"));
+#ifdef __ANDROID__
+  const char* default_temp_dir_c_str = "/data/local/tmp";
+#else
+  const char* default_temp_dir_c_str = "/tmp";
+#endif
+  std::string temp_dir = std::string(temp_dir_c_str == NULL ?
+      default_temp_dir_c_str : temp_dir_c_str);
+  return temp_dir;
+#endif  // _WIN32
+}
+
+/// \brief Convert a `Storage::DataStruct` to string.
+static std::string data_struct_to_str(
+    const Storage::DataStruct data_struct) {
+  switch (data_struct) {
+    case Storage::DataStruct::kDataEntry:      return "data entry";
+    case Storage::DataStruct::kTempSpace:      return "temp space";
+    case Storage::DataStruct::kParameter:      return "param";
+    case Storage::DataStruct::kParameterGrad:  return "param grad";
+    case Storage::DataStruct::kOptimizerState: return "optimizer state";
+    case Storage::DataStruct::kAuxState:       return "aux state";
+    case Storage::DataStruct::kEphemeral:      return "ephemeral";
+    default: return "unknown";
+  }
+}
+
+GpuMemoryProfiler*
+GpuMemoryProfiler::Get() {
+  static GpuMemoryProfiler s_gpu_memory_profiler;
+  return &s_gpu_memory_profiler;
+}
+
+GpuMemoryProfiler::GpuMemoryProfiler() {
+  enabled_ = dmlc::GetEnv("MXNET_USE_PROFILER", false);
+
+  if (enabled_) {
+    std::string temp_dir = temp_dir_path(),
+                alloc_csv_fname = temp_dir + "mxnet_gpu_memory_profiler_alloc.csv";
+
+    alloc_csv_fout_.open(alloc_csv_fname.c_str());
+    CHECK_EQ(alloc_csv_fout_.is_open(), true);
+    // add the CSV header
+    alloc_csv_fout_ << "\"Time Stamp\",\"Scope\",\"Attribute Name\","
+                       "\"Data Struct\","
+                       "\"Requested\",\"Actual\",\"Reuse?\""
+                    << std::endl;
+  }  // enabled_
+}
+
+static std::string s_current_profiler_scope = "<unk>:";
+
+void
+GpuMemoryProfiler::SetCurrentScope(const std::string& scope) {
+  s_current_profiler_scope = scope;
+}
+
+std::string
+GpuMemoryProfiler::GetCurrentScope() {
+  return s_current_profiler_scope;
+}
+
+void
+GpuMemoryProfiler::addEntry(const Storage::Handle& handle,
+    const size_t actual_alloc_size, const bool reuse) {
+  // directly skip the recording if the memory profiler is not enabled or
+  // the storage handle has been marked as 'ephemeral'
+  if (!enabled_ ||
+      handle.data_struct == Storage::DataStruct::kEphemeral) {
+    return;
+  }
+  alloc_csv_fout_ << static_cast<unsigned long>(time(NULL)) << ","
+                  << "\"" << handle.profiler_scope << "\","
+                  << "\"" << handle.name  << "\","
+                  << "\"" << data_struct_to_str(handle.data_struct) << "\","
+                  << handle.size << ","
+                  << actual_alloc_size << ","
+                  << reuse << std::endl;
+}
+
+}  // namespace profiler
+}  // namespace mxnet

--- a/src/profiler/gpu_memory_profiler.h
+++ b/src/profiler/gpu_memory_profiler.h
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+#ifndef MXNET_PROFILER_GPU_MEMORY_PROFILER_H_
+#define MXNET_PROFILER_GPU_MEMORY_PROFILER_H_
+
+#include <fstream>
+#include <string>
+#include <mxnet/storage.h>
+
+namespace mxnet {
+namespace profiler {
+
+class GpuMemoryProfiler {
+ public:
+  /// \brief Get the global instance of the memory profiler
+  ///        to record an allocation entry.
+  static GpuMemoryProfiler* Get();
+  GpuMemoryProfiler();
+  /// \brief Set/Get the profiler scope.
+  static void SetCurrentScope(const std::string& scope);
+  static std::string GetCurrentScope();
+  /// \brief Record an allocation entry in the profiler.
+  void addEntry(const Storage::Handle& handle,
+      const size_t actual_alloc_size, const bool reuse);
+private:
+  bool enabled_;
+  std::ofstream alloc_csv_fout_;
+};
+
+}  // namespace profiler
+}  // namespace mxnet
+
+#endif  // MXNET_PROFILER_GPU_MEMORY_PROFILER_H_

--- a/src/resource.cc
+++ b/src/resource.cc
@@ -29,7 +29,6 @@
 #include <mxnet/engine.h>
 #include <mxnet/random_generator.h>
 #include <mxnet/resource.h>
-#include <mxnet/storage.h>
 #include <limits>
 #include <atomic>
 #include "./common/lazy_alloc_array.h"
@@ -65,11 +64,13 @@ struct SpaceAllocator {
     host_handle.size = 0;
   }
 
-  inline void* GetSpace(size_t size) {
+  inline void* GetSpace(size_t size, const std::string &name) {
     if (handle.size >= size) return handle.dptr;
 
     Storage::Get()->DirectFree(handle);
-    handle = Storage::Get()->Alloc(size, ctx);
+    handle = Storage::Get()->Alloc(size, ctx,
+        "resource:", name,
+        Storage::DataStruct::kTempSpace);
     return handle.dptr;
   }
 
@@ -410,8 +411,9 @@ class ResourceManagerImpl : public ResourceManager {
 };
 }  // namespace resource
 
-void* Resource::get_space_internal(size_t size) const {
-  return static_cast<resource::SpaceAllocator*>(ptr_)->GetSpace(size);
+void* Resource::get_space_internal(size_t size,
+    const std::string &name) const {
+  return static_cast<resource::SpaceAllocator*>(ptr_)->GetSpace(size, name);
 }
 
 void* Resource::get_host_space_internal(size_t size) const {
@@ -420,27 +422,29 @@ void* Resource::get_host_space_internal(size_t size) const {
 
 #if MXNET_USE_CUDNN == 1
 void Resource::get_cudnn_dropout_desc(
-    cudnnDropoutDescriptor_t* dropout_desc,
+    cudnnDropoutDescriptor_t *dropout_desc,
     mshadow::Stream<gpu> *stream,
-    const float dropout,
-    uint64_t seed) const {
+    const float dropout, uint64_t seed,
+    const std::string &name) const {
 
   CHECK_EQ(req.type, ResourceRequest::kCuDNNDropoutDesc);
   auto state_space = static_cast<resource::SpaceAllocator*>(ptr_);
   CHECK_EQ(state_space->ctx.dev_id, stream->dev_id)
-    << "The device id of cudnn dropout state space doesn't match that from stream.";
+    << "The device id of cuDNN dropout state space doesn't match that from stream.";
   if (!state_space->handle.size) {
     // not initialized yet.
     size_t dropout_state_size;
     CUDNN_CALL(cudnnDropoutGetStatesSize(stream->dnn_handle_, &dropout_state_size));
     // reserve GPU space
     Storage::Get()->DirectFree(
-      Storage::Get()->Alloc(dropout_state_size, state_space->ctx));
+        Storage::Get()->Alloc(dropout_state_size,
+          state_space->ctx,
+          "ephemeral:", "dropout_reserve",
+          Storage::DataStruct::kEphemeral));
     CUDNN_CALL(cudnnSetDropoutDescriptor(*dropout_desc, stream->dnn_handle_,
                                          dropout,
-                                         state_space->GetSpace(dropout_state_size),
-                                         dropout_state_size,
-                                         seed));
+                                         state_space->GetSpace(dropout_state_size, name),
+                                         dropout_state_size, seed));
   } else {
     // cudnnRestoreDropoutDescriptor() introduced with cuDNN v7
     STATIC_ASSERT_CUDNN_VERSION_GE(7000);

--- a/src/storage/gpu_device_storage.h
+++ b/src/storage/gpu_device_storage.h
@@ -28,6 +28,7 @@
 #include "mxnet/base.h"
 #include "mxnet/storage.h"
 #include "../common/cuda_utils.h"
+#include "../profiler/gpu_memory_profiler.h"
 #if MXNET_USE_CUDA
 #include <cuda_runtime.h>
 #endif  // MXNET_USE_CUDA
@@ -66,6 +67,8 @@ inline void GPUDeviceStorage::Alloc(Storage::Handle* handle) {
   cudaError_t e = cudaMalloc(&handle->dptr, size);
   if (e != cudaSuccess && e != cudaErrorCudartUnloading)
     LOG(FATAL) << "CUDA: " << cudaGetErrorString(e);
+  // record the allocation event in the memory profiler
+  profiler::GpuMemoryProfiler::Get()->addEntry(*handle, size, false);
 #else   // MXNET_USE_CUDA
   LOG(FATAL) << "Please compile with CUDA enabled";
 #endif  // MXNET_USE_CUDA

--- a/src/storage/pinned_memory_storage.h
+++ b/src/storage/pinned_memory_storage.h
@@ -30,6 +30,7 @@
 #include "mxnet/base.h"
 #include "mxnet/storage.h"
 #include "../common/cuda_utils.h"
+#include "../profiler/gpu_memory_profiler.h"
 
 namespace mxnet {
 namespace storage {
@@ -60,6 +61,8 @@ inline void PinnedMemoryStorage::Alloc(Storage::Handle* handle) {
   mxnet::common::cuda::DeviceStore device_store(handle->ctx.real_dev_id(), true);
   // make the memory available across all devices
   CUDA_CALL(cudaHostAlloc(&handle->dptr, size, cudaHostAllocPortable));
+  // record the allocation event in the memory profiler
+  profiler::GpuMemoryProfiler::Get()->addEntry(*handle, size, false);
 }
 
 inline void PinnedMemoryStorage::Free(Storage::Handle handle) {

--- a/src/storage/pooled_storage_manager.h
+++ b/src/storage/pooled_storage_manager.h
@@ -39,6 +39,7 @@
 #include "./storage_manager.h"
 #include "../common/cuda_utils.h"
 #include "../common/utils.h"
+#include "../profiler/gpu_memory_profiler.h"
 
 
 namespace mxnet {
@@ -166,11 +167,15 @@ void GPUPooledStorageManager::Alloc(Storage::Handle* handle) {
     }
     used_memory_ += size;
     handle->dptr = ret;
+    // record the allocation event in the memory profiler
+    profiler::GpuMemoryProfiler::Get()->addEntry(*handle, size, false);
   } else {
     auto&& reuse_pool = reuse_it->second;
     auto ret = reuse_pool.back();
     reuse_pool.pop_back();
     handle->dptr = ret;
+    // record the allocation event in the memory profiler
+    profiler::GpuMemoryProfiler::Get()->addEntry(*handle, size, true);
   }
 }
 
@@ -349,10 +354,14 @@ void GPUPooledRoundedStorageManager::Alloc(Storage::Handle* handle) {
     }
     used_memory_ += size;
     handle->dptr = ret;
+    // record the allocation event in the memory profiler
+    profiler::GpuMemoryProfiler::Get()->addEntry(*handle, size, false);
   } else {
     auto ret = reuse_pool.back();
     reuse_pool.pop_back();
     handle->dptr = ret;
+    // record the allocation event in the memory profiler
+    profiler::GpuMemoryProfiler::Get()->addEntry(*handle, size, true);
   }
 }
 


### PR DESCRIPTION
## Description ##
implement storage tagging, the first half of the memory profiler

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [x] This PR is the first half of the GPU memory profiler. It implements storage tagging which adds profiler scope, name, and data structure information to each allocated storage handle.

FYI, @szha @eric-haibin-lin
